### PR TITLE
Add a flag to set the "no template params" option to c++filt.go

### DIFF
--- a/c++filt.go
+++ b/c++filt.go
@@ -37,6 +37,7 @@ If no names are provided on the command line, stdin is read.`)
 
 var stripUnderscore = flag.Bool("_", false, "Ignore first leading underscore")
 var noParams = flag.Bool("p", false, "Do not display function argument types")
+var noTemplateParams = flag.Bool("T", false, "Do not display template parameters")
 var noVerbose = flag.Bool("i", false, "Do not show implementation details (if any)")
 var help = flag.Bool("h", false, "Display help information")
 var debug = flag.Bool("d", false, "Display debugging information for strings on command line")
@@ -136,6 +137,9 @@ func options() []demangle.Option {
 	var options []demangle.Option
 	if *noParams {
 		options = append(options, demangle.NoParams)
+	}
+	if *noTemplateParams {
+		options = append(options, demangle.NoTemplateParams)
 	}
 	if !*noVerbose {
 		options = append(options, demangle.Verbose)


### PR DESCRIPTION
This is useful during experimentation.