### PR TITLE
demangle: gofmt with Go 1.14

### DIFF
--- a/demangle.go
+++ b/demangle.go
@@ -250,6 +250,7 @@ func adjustErr(err error, adj int) error {
 }
 
 type forLocalNameType int
+
 const (
 	forLocalName forLocalNameType = iota
 	notForLocalName


### PR DESCRIPTION
Noticed while running gofmt against Go tip and thus the vendored copy of
this package.