### PR TITLE
Make sure to not modify the input options slice.

### DIFF
--- a/demangle.go
+++ b/demangle.go
@@ -186,7 +186,8 @@ func ToAST(name string, options ...Option) (AST, error) {
 		i := 0
 		for i < len(options) {
 			if options[i] == NoParams {
-				options = append(options[:i], options[i+1:]...)
+				// Make sure not to modify the original slice's backing storage.
+				options = append(append(make([]Option, 0, len(options)-1), options[:i]...), options[i+1:]...)
 			} else {
 				i++
 			}


### PR DESCRIPTION
In Go, appending to a slice can modify the original slice if there is enough backing space. In use cases like passing options slice to an API call this is unexpected since it's quite intuitive at the API surface to write a loop to demangle multiple names and reuse the same options slice between the calls. Forcing clients to copy or re-create the options in such pattern seems unnecessary.