### PR TITLE
demangle: don't panic on empty unqualified names

### DIFF
--- a/demangle.go
+++ b/demangle.go
@@ -906,9 +906,10 @@ func (st *state) unqualifiedName(module AST) (r AST, isCast bool) {
 	if len(st.str) > 0 && st.str[0] == 'F' {
 		st.advance(1)
 		friend = true
-		if len(st.str) < 1 {
-			st.fail("expected unqualified name")
-		}
+	}
+
+	if len(st.str) < 1 {
+		st.fail("expected unqualified name")
 	}
 
 	var a AST

--- a/testdata/demangle-expected
+++ b/testdata/demangle-expected
@@ -1493,3 +1493,7 @@ decltype ({parm#1}.A::x) f<A>(A)
 
 _Z2f6IP1AEDtptfp_gssr1A1BE1xET_
 decltype ({parm#1}->(::A::B::x)) f6<A*>(A*)
+
+# Tests a `runtime error: index out of range [0]` panic.
+_ZNW5_upee
+_ZNW5_upee


### PR DESCRIPTION
When fuzzing google/syzkaller, OSS-Fuzz has come up with a `_ZNW5_upee` input that has a valid module name, yet lacks an unqualified name, which caused a `runtime error: index out of range [0] with length 0` error at demangle.go:916.

Fix it by checking `len(st.str)` before accessing `st.str[0]`.