### PR TITLE
demangle: support Clang __alloc_token_ instrumentation prefix

### DIFF
--- a/demangle.go
+++ b/demangle.go
@@ -150,8 +150,25 @@ func ToString(name string, options ...Option) (string, error) {
 // error will be ErrNotMangledName.
 // This function does not currently support Rust symbol names.
 func ToAST(name string, options ...Option) (AST, error) {
+	// Clang AllocToken instrumentation.
+	allocToken := false
+	if strings.HasPrefix(name, "__alloc_token_") {
+		allocToken = true
+		name = name[len("__alloc_token_"):]
+		i := 0
+		for i < len(name) && isDigit(name[i]) {
+			i++
+		}
+		if i > 0 && i < len(name) && name[i] == '_' {
+			name = name[i+1:]
+		}
+	}
+
 	if strings.HasPrefix(name, "_Z") {
 		a, err := doDemangle(name[2:], options...)
+		if err == nil && allocToken {
+			a = &Clone{Base: a, Suffix: ".alloc_token"}
+		}
 		return a, adjustErr(err, 2)
 	}
 

--- a/testdata/DemangleTestCases.inc
+++ b/testdata/DemangleTestCases.inc
@@ -30219,4 +30219,15 @@
 {"_Z3fooIPU9__ptrauthILj1ELb0ELj64EEPiEvT_", "void foo<int* __ptrauth<1u, false, 64u>*>(int* __ptrauth<1u, false, 64u>*)"},
 
 {"_ZN1CpmEi", "C::operator->*(int)"},
+
+// AllocToken instrumentation
+{"__alloc_token__Znwm", "operator new(unsigned long) (.alloc_token)"},
+{"__alloc_token__Znam", "operator new[](unsigned long) (.alloc_token)"},
+{"__alloc_token__ZnwmRKSt9nothrow_t", "operator new(unsigned long, std::nothrow_t const&) (.alloc_token)"},
+{"__alloc_token__ZnamRKSt9nothrow_t", "operator new[](unsigned long, std::nothrow_t const&) (.alloc_token)"},
+{"__alloc_token_0__Znwm", "operator new(unsigned long) (.alloc_token)"},
+{"__alloc_token_1__Znam", "operator new[](unsigned long) (.alloc_token)"},
+{"__alloc_token_123__ZnwmRKSt9nothrow_t", "operator new(unsigned long, std::nothrow_t const&) (.alloc_token)"},
+{"__alloc_token__Znwm.llvm.1234", "operator new(unsigned long) (.llvm.1234) (.alloc_token)"},
+{"__alloc_token_123__Z3foov", "foo() (.alloc_token)"},
     // clang-format on


### PR DESCRIPTION
Update the demangler to recognize and strip `__alloc_token_` prefixes introduced by AllocToken instrumentation in Clang [1]. This ensures that instrumented allocation functions (e.g., `__alloc_token__Znwm`) demangle back to their original source-level names with a suffix `(.alloc_token)` indicating their origin.

This matches the behavior in the LLVM Itanium demangler (see updated LLVM test file).

[1] https://clang.llvm.org/docs/AllocToken.html